### PR TITLE
Correctly sourcing version

### DIFF
--- a/dejavu.py
+++ b/dejavu.py
@@ -8,8 +8,8 @@ import argparse
 from dejavu import Dejavu
 from dejavu.recognize import FileRecognizer
 from dejavu.recognize import MicrophoneRecognizer
+from dejavu.version import __version__
 from argparse import RawTextHelpFormatter
-from dejavu.version import Version
 
 warnings.filterwarnings("ignore")
 
@@ -59,7 +59,7 @@ if __name__ == '__main__':
     parser.add_argument(
         '--version',
         action='version',
-        version=Version.version()
+        version=__version__
     )
 
     args = parser.parse_args()

--- a/dejavu/version.py
+++ b/dejavu/version.py
@@ -1,5 +1,1 @@
-class Version:
-
-    @classmethod
-    def version(cls):
-        return '1.3.2'
+__version__ = '1.3.2'

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 from setuptools import setup, find_packages
-from dejavu.version import Version as v
 
 
 def parse_requirements(requirements):
@@ -16,7 +15,7 @@ def parse_requirements(requirements):
 
 
 PACKAGE_NAME = "PyDejavu"
-PACKAGE_VERSION = v.version()
+PACKAGE_VERSION = '1.3.2'
 SUMMARY = 'Dejavu: Audio Fingerprinting in Python'
 DESCRIPTION = """
 Audio fingerprinting and recognition algorithm implemented in Python

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 from setuptools import setup, find_packages
-
+import os
 
 def parse_requirements(requirements):
     # load from requirements.txt
@@ -14,8 +14,14 @@ def parse_requirements(requirements):
         return reqs
 
 
+base_dir = os.path.dirname(__file__)
+
+version = {}
+with open(os.path.join(base_dir, "dejavu", "version.py")) as f:
+    exec(f.read(), version)
+
 PACKAGE_NAME = "PyDejavu"
-PACKAGE_VERSION = '1.3.2'
+PACKAGE_VERSION = version["__version__"]
 SUMMARY = 'Dejavu: Audio Fingerprinting in Python'
 DESCRIPTION = """
 Audio fingerprinting and recognition algorithm implemented in Python


### PR DESCRIPTION
This fixes an error where `setup.py` fails because it tries to import the package modules 'before' they are installed (via `from dejavu.version import Version as v`).

Didn't realise you can import the variable in.